### PR TITLE
Use the new datasets and reuses organization API

### DIFF
--- a/js/components/dataset/list.vue
+++ b/js/components/dataset/list.vue
@@ -10,6 +10,22 @@
 <script>
 'use strict';
 
+var Vue = require('vue'),
+    LABELS = {
+        deleted: {
+            label: Vue._('Deleted'),
+            type: 'error'
+        },
+        private: {
+            label: Vue._('Private'),
+            type: 'warning'
+        },
+        public: {
+            label: Vue._('Public'),
+            type: 'info'
+        }
+    };
+
 module.exports = {
     name: 'datasets-widget',
     components: {
@@ -58,6 +74,11 @@ module.exports = {
                 sort: 'views',
                 align: 'center',
                 type: 'metric',
+                width: 95
+            }, {
+                label: this._('Status'),
+                align: 'center',
+                type: 'visibility',
                 width: 95
             }]
         };

--- a/js/components/reuse/list.vue
+++ b/js/components/reuse/list.vue
@@ -63,6 +63,11 @@ module.exports = {
                 align: 'center',
                 type: 'metric',
                 width: 95
+            }, {
+                label: this._('Status'),
+                align: 'center',
+                type: 'visibility',
+                width: 95
             }]
         };
     },

--- a/js/models/base_list.js
+++ b/js/models/base_list.js
@@ -39,6 +39,11 @@ define(['api', 'vue', 'jquery'], function(API, Vue, $) {
                     return item.hasOwnProperty('id') && item.id === id;
                 });
                 return filtered.length === 1 ? filtered[0] : null;
+            },
+            clear: function() {
+                this.items = [];
+                this.$emit('updated');
+                return this;
             }
         }
     });

--- a/js/views/organization.vue
+++ b/js/views/organization.vue
@@ -36,6 +36,7 @@
 
 var moment = require('moment'),
     URLs = require('urls'),
+    List = require('models/base_page_list'),
     Organization = require('models/organization'),
     Datasets = require('models/datasets'),
     Reuses = require('models/reuses'),
@@ -52,8 +53,14 @@ module.exports = {
                 start: moment().subtract(15, 'days').format('YYYY-MM-DD'),
                 end: moment().format('YYYY-MM-DD')
             }}),
-            reuses: new Reuses({query: {sort: '-created', page_size: 10}}),
-            datasets: new Datasets({query: {sort: '-created', page_size: 10}}),
+            reuses: new List({
+                ns: 'organizations',
+                fetch: 'list_organization_reuses',
+            }),
+            datasets: new List({
+                ns: 'organizations',
+                fetch: 'list_organization_datasets'
+            }),
             followers: new Followers({query: {page_size: 10}}),
             meta: {
                 title: null,
@@ -178,8 +185,8 @@ module.exports = {
         'org.id': function(id) {
             if (id) {
                 this.metrics.fetch({id: id});
-                this.reuses.clear().fetch({organization: id});
-                this.datasets.clear().fetch({organization: id});
+                this.reuses.clear().fetch({org: id});
+                this.datasets.clear().fetch({org: id});
                 this.followers.fetch({id: id});
             } else {
                 this.datasets.clear();


### PR DESCRIPTION
This pull-request make use of organization reuses and datasets APIs to avoid hitting the server on sort and paging.

It also allows to display private datasets and reuses and so a specific column has been added to the widget.