### PR TITLE
Better agencement for actions, fix #19

### DIFF
--- a/js/components/content-header.vue
+++ b/js/components/content-header.vue
@@ -30,13 +30,6 @@
     <section class="content-header">
         <h1>
             {{$root.meta.title}}
-            <small v-if="$root.meta.subtitle">{{$root.meta.subtitle}}</small>
-        </h1>
-        <div class="btn-group  btn-group-sm btn-actions pull-right clearfix">
-            <a v-if="$root.meta.page" class="btn btn-link" href="{{$root.meta.page}}"
-                title="{{ _('See on the site') }}">
-                <span class="fa fa-fw fa-bookmark"></span>
-            </a>
             <div v-if="$root.meta.actions && $root.meta.actions.length"
                 class="btn-group" role="group">
                 <a class="btn btn-link btn-sm dropdown-toggle"
@@ -52,6 +45,13 @@
                     </li>
                 </ul>
             </div>
+            <small v-if="$root.meta.subtitle">{{$root.meta.subtitle}}</small>
+        </h1>
+        <div class="btn-group  btn-group-sm btn-actions pull-right clearfix">
+            <a v-if="$root.meta.page" class="btn btn-link" href="{{$root.meta.page}}"
+                title="{{ _('See it as viewed by visitors') }}">
+                {{ _('See on the site') }} →
+            </a>
         </div>
     </section>
 </template>


### PR DESCRIPTION
Before:

![capture d ecran 2015-07-06 a 11 05 16](https://cloud.githubusercontent.com/assets/3556/8519046/be155d5e-23cf-11e5-9b6a-723ab5447bbc.png)

After:

![capture d ecran 2015-07-06 a 11 05 04](https://cloud.githubusercontent.com/assets/3556/8519052/c7f27f14-23cf-11e5-91d0-375a9c1b9d53.png)

The link to the website is now [explicit with a label](http://thomasbyttebier.be/blog/the-best-icon-is-a-text-label) and actions related to the item are closer to the title.