### PR TITLE
Use Sifter for sort and filter on local list (and test it)

### DIFF
--- a/js/components/widgets/datatable.vue
+++ b/js/components/widgets/datatable.vue
@@ -31,7 +31,7 @@
                     style="width: 150px;" placeholder="{{'Search'|i18n}}"
                     v-model="search_query" v-on="keyup:search | key enter">
                 <div class="input-group-btn">
-                    <button class="btn btn-sm btn-flat">
+                    <button class="btn btn-sm btn-flat" v-on="click: search">
                         <i class="fa fa-search"></i>
                     </button>
                 </div>

--- a/js/views/organization.vue
+++ b/js/views/organization.vue
@@ -78,10 +78,12 @@ export default {
             reuses: new PageList({
                 ns: 'organizations',
                 fetch: 'list_organization_reuses',
+                search: 'title'
             }),
             datasets: new PageList({
                 ns: 'organizations',
-                fetch: 'list_organization_datasets'
+                fetch: 'list_organization_datasets',
+                search: 'title'
             }),
             issues: new PageList({
                 ns: 'organizations',

--- a/package.json
+++ b/package.json
@@ -10,14 +10,15 @@
     "build": "webpack -p"
   },
   "devDependencies": {
-    "chai": "^3.0.0",
     "babel-core": "^5.5.7",
     "babel-loader": "^5.1.4",
+    "chai": "^3.0.0",
     "chai-jquery": "^2.0.0",
     "chai-things": "^0.2.0",
     "css-loader": "^0.14.5",
     "exports-loader": "^0.6.2",
     "extract-text-webpack-plugin": "^0.8.2",
+    "faker": "^3.0.0",
     "file-loader": "^0.8.4",
     "html-loader": "^0.3.0",
     "image-webpack-loader": "^1.6.1",

--- a/specs/models/base.specs.js
+++ b/specs/models/base.specs.js
@@ -1,12 +1,12 @@
 import API from 'specs/mocks/api';
-import {Model} from 'models/base';
+import {Model, PageList} from 'models/base';
 import Vue from 'vue';
 
 Vue.config.async = false;
 
 describe('Base model', function() {
 
-    var PetSchema = {
+    const PetSchema = {
         required: ['id', 'name'],
         properties: {
             id: {type: 'integer', format: 'int64'},
@@ -26,14 +26,14 @@ describe('Base model', function() {
 
 
         it("should use the specs schema", function() {
-            var pet = new Pet();
+            let pet = new Pet();
 
             expect(pet.__schema__).not.to.be.undefined;
             expect(pet.__schema__).to.deep.equals(PetSchema);
         });
 
         it("should populate required data with the schema", function() {
-            var pet = new Pet();
+            let pet = new Pet();
 
             expect(pet.id).to.be.null;
             expect(pet.name).to.be.null;
@@ -41,7 +41,7 @@ describe('Base model', function() {
         });
 
         it('can be populated with the data', function() {
-            var pet = new Pet({
+            let pet = new Pet({
                     data: {
                         id: 1,
                         name: 'Rex',
@@ -57,7 +57,7 @@ describe('Base model', function() {
         describe("Vue.js integration", function() {
 
             it('allows to watch undefined properties', function(done) {
-                var vm = new Vue({
+                let vm = new Vue({
                     data: {
                         pet: new Pet()
                     },
@@ -79,7 +79,7 @@ describe('Base model', function() {
 
         describe('Validation', function() {
             it("should validate complete valid models", function() {
-                var pet = new Pet({
+                let pet = new Pet({
                         data: {
                             id: 1,
                             name: 'Rex',
@@ -87,7 +87,7 @@ describe('Base model', function() {
                         }
                     });
 
-                var result = pet.validate();
+                let result = pet.validate();
 
                 expect(result.valid).to.be.true;
                 expect(result.errors.length).to.equal(0);
@@ -95,7 +95,7 @@ describe('Base model', function() {
             });
 
             it("should validate complete valid nested models", function() {
-                var pet = new Pet({
+                let pet = new Pet({
                         data: {
                             id: 1,
                             name: 'Rex',
@@ -103,7 +103,7 @@ describe('Base model', function() {
                         }
                     });
 
-                var result = pet.validate();
+                let result = pet.validate();
 
                 expect(result.valid).to.be.true;
                 expect(result.errors.length).to.equal(0);
@@ -112,14 +112,14 @@ describe('Base model', function() {
 
             xit("should validate partial valid models", function() {
                 // Need https://github.com/geraintluff/tv4/pull/175
-                var pet = new Pet({
+                let pet = new Pet({
                         data: {
                             id: 1,
                             name: 'Rex'
                         }
                     });
 
-                var result = pet.validate();
+                let result = pet.validate();
 
                 expect(result.valid).to.be.true;
                 expect(result.errors.length).to.equal(0);
@@ -147,8 +147,8 @@ describe('Base model', function() {
             });
         });
 
-        it("should populate required data with the schema", function() {
-            var person = new Person();
+        it('should populate required data with the schema', function() {
+            let person = new Person();
 
             expect(person.id).to.be.null;
             expect(person.name).to.be.null;
@@ -157,7 +157,7 @@ describe('Base model', function() {
         });
 
         it('can be populated with the data', function() {
-            var person = new Person({
+            let person = new Person({
                     data: {
                         id: 1,
                         name: 'Axel',
@@ -178,12 +178,12 @@ describe('Base model', function() {
             expect(person.pet.name).to.equal('Rex');
         });
 
-        describe("Vue.js integration", function() {
+        describe('Vue.js integration', function() {
 
             it('allows to watch undefined properties', function(done) {
-                var vm = new Vue({
+                let vm = new Vue({
                         data: {
-                            person = new Person()
+                            person: new Person()
                         },
                         watch: {
                             'person.pet.name': function(value, old) {

--- a/specs/models/lists.specs.js
+++ b/specs/models/lists.specs.js
@@ -1,0 +1,460 @@
+import API from 'specs/mocks/api';
+import {List, ModelPage, PageList, DEFAULT_PAGE_SIZE} from 'models/base';
+import Vue from 'vue';
+import URL from 'url';
+import faker from 'faker';
+
+Vue.config.async = false;
+
+const ThingSchema = {
+    required: ['id', 'name'],
+    properties: {
+        id: {type: 'integer', format: 'int64'},
+        name: {type: 'string'},
+        tag: {type: 'string'}
+    }
+};
+
+let factoryIndex = 1;
+
+function thingFactory(n, string) {
+    let data = [],
+        end = factoryIndex + (n || 1);
+
+    for (factoryIndex; factoryIndex < end; factoryIndex++) {
+        data.push({id: factoryIndex, name: faker.fake(string || '{{name.findName}}')});
+    }
+
+    return data;
+}
+
+describe('Base lists', function() {
+    before(function() {
+        API.mock_specs({
+            definitions: {
+                Thing: ThingSchema
+            },
+            paths: {
+                '/thing/{id}/': {
+                    get: {
+                        operationId: 'list_things',
+                        parameters: [{
+                            in: 'path',
+                            name: 'id',
+                            required: true,
+                            type: 'string'
+                        }],
+                        responses: {
+                            '200': {
+                                description: 'Success',
+                                schema: {
+                                    items: {
+                                        $ref: '#/definitions/Thing'
+                                    },
+                                    type: 'array'
+                                }
+                            }
+                        },
+                        tags: ['things']
+                    }
+                }
+            }
+        });
+    });
+
+    beforeEach(function() {
+        factoryIndex = 1;
+        this.xhr = sinon.useFakeXMLHttpRequest();
+        let requests = this.requests = [];
+        this.xhr.onCreate = function (req) { requests.push(req); };
+    });
+
+    afterEach(function() {
+        this.xhr.restore();
+    });
+
+    describe('List', function() {
+        it('should populate data from constructor', function() {
+            let list = new List({
+                    data: thingFactory(3)
+                });
+
+            expect(this.requests).to.have.length(0);
+            expect(list.loading).to.be.false;
+            expect(list.items).to.have.length(3);
+            expect(list.data).to.eql(list.items);
+        });
+
+        it('should fetch a list from the server', function() {
+            let list = new List({
+                    ns: 'things',
+                    fetch: 'list_things'
+                }),
+                response = JSON.stringify(thingFactory(3));
+
+            expect(list.items).to.have.length(0);
+            expect(list.loading).to.be.false;
+            list.fetch({id: 'abc'});
+
+            expect(this.requests).to.have.length(1);
+            expect(list.loading).to.be.true;
+
+            let request = this.requests[0],
+                url = URL.parse(request.url);
+
+            expect(request.method).to.equal('GET');
+            expect(url.pathname).to.equal('/thing/abc/');
+
+            request.respond(200, {'Content-Type': 'application/json'}, response);
+
+            expect(list.items).to.have.length(3);
+            expect(list.data).to.eql(list.items);
+            expect(list.loading).to.be.false;
+        });
+
+        it('should perform sorting without server calls', function() {
+            let list = new List({
+                    data: thingFactory(2).concat(thingFactory(1, 'aaa'), thingFactory(1, 'zzz')),
+                });
+
+            expect(list.items).to.have.length(4);
+            expect(list.data).to.have.length(4);
+            expect(list.data[0].id).to.equal(1);
+
+            // Sort ascending
+            list.sort('name', false);
+            expect(list.data[0].name).to.equal('aaa');
+            expect(list.data[list.data.length - 1].name).to.equal('zzz');
+
+            // Sort descending
+            list.sort('name', true);
+            expect(list.data[0].name).to.equal('zzz');
+            expect(list.data[list.data.length - 1].name).to.equal('aaa');
+
+            // Sort toggle (reverse current sort)
+            list.sort('name');
+            expect(list.data[0].name).to.equal('aaa');
+            expect(list.data[list.data.length - 1].name).to.equal('zzz');
+
+            expect(this.requests).to.have.length(0);
+        });
+
+        it('should perform client side filtering on a field', function() {
+            let list = new List({
+                    data: [
+                        {id: 1, name: 'abc'},
+                        {id: 2, name: 'aaa'},
+                        {id: 3, name: 'bbb'},
+                        {id: 4, name: 'ccc'},
+                    ],
+                    search: 'name'
+                });
+
+            expect(list.has_search).to.be.true;
+            expect(list.data).to.have.length(4);
+            expect(list.items).to.have.length(4);
+
+            list.search('a');
+
+            expect(list.data).to.have.length(2);
+            expect(list.items).to.have.length(4);
+
+            expect(this.requests).to.have.length(0);
+        });
+
+        it('should perform client side filtering on multiple fields', function() {
+            let list = new List({
+                    data: [
+                        {id: 1, name: 'abc', tag: 'xxx'},
+                        {id: 2, name: 'aaa', tag: 'xxx'},
+                        {id: 3, name: 'bbb', tag: 'aaa'},
+                        {id: 4, name: 'ccc', tag: 'yyy'},
+                    ],
+                    search: ['name', 'tag']
+                });
+
+            expect(list.has_search).to.be.true;
+            expect(list.data).to.have.length(4);
+            expect(list.items).to.have.length(4);
+
+            list.search('a');
+
+            expect(list.data).to.have.length(3);
+            expect(list.items).to.have.length(4);
+
+            expect(this.requests).to.have.length(0);
+        });
+
+        describe('Vue.js integration', function() {
+
+            afterEach(function() {
+                fixture.cleanup();
+            });
+
+            it('allows to watch changes', function() {
+                let vm = new Vue({
+                        el: fixture.set('<div/>')[0],
+                        template: `<ul v-el="list">
+                                        <li v-repeat=things.data>{{name}}</li>
+                                    </ul>`,
+                        data: {
+                            things: new List({
+                                ns: 'things',
+                                fetch: 'list_things'
+                            })
+                        }
+                    }),
+                    response = JSON.stringify(thingFactory(3));
+
+                expect(vm.$$.list.children).to.have.length(0);
+                vm.things.fetch({id: 'abc'});
+                this.requests[0].respond(200, {'Content-Type': 'application/json'}, response);
+
+                expect(vm.$$.list.children).to.have.length(3);
+            });
+
+        });
+    });
+
+    describe('PageList', function() {
+        it('should have sane default values', function() {
+            let list = new PageList();
+
+            expect(this.requests).to.have.length(0);
+            expect(list.loading).to.be.false;
+            expect(list.items).to.have.length(0);
+            expect(list.data).to.have.length(0);
+            expect(list.page_size).to.equal(DEFAULT_PAGE_SIZE);
+            expect(list.page).to.equal(1);
+            expect(list.pages).to.equal(0);
+            expect(list.reversed).to.be.false;
+            expect(list.has_search).to.be.false;
+            expect(list.sorted).to.be.null;
+        });
+
+        it('should populate data from constructor', function() {
+            let list = new PageList({
+                    data: thingFactory(3)
+                });
+
+            expect(this.requests).to.have.length(0);
+            expect(list.loading).to.be.false;
+            expect(list.items).to.have.length(3);
+            expect(list.data).to.have.length.below(list.page_size);
+            expect(list.page_size).to.equal(DEFAULT_PAGE_SIZE);
+            expect(list.page).to.equal(1);
+            expect(list.pages).to.equal(1);
+            expect(list.reversed).to.be.false;
+            expect(list.has_search).to.be.false;
+            expect(list.sorted).to.be.null;
+        });
+
+        it('should allow to specify a page size', function() {
+            let list = new PageList({
+                    data: thingFactory(10),
+                    page_size: 5
+                });
+
+            expect(list.items).to.have.length(10);
+            expect(list.data).to.have.length(list.page_size);
+            expect(list.page_size).to.equal(5);
+            expect(list.page).to.equal(1);
+            expect(list.pages).to.equal(2);
+        });
+
+        it('should fetch a list from the server', function() {
+            let list = new PageList({
+                    ns: 'things',
+                    fetch: 'list_things'
+                }),
+                response = JSON.stringify(thingFactory(3));
+
+            list.fetch({id: 'abc'});
+
+            expect(this.requests).to.have.length(1);
+            expect(list.loading).to.be.true;
+
+            let request = this.requests[0],
+                url = URL.parse(request.url);
+
+            expect(request.method).to.equal('GET');
+            expect(url.pathname).to.equal('/thing/abc/');
+
+            request.respond(200, {'Content-Type': 'application/json'}, response);
+
+            expect(list.items).to.have.length(3);
+            expect(list.loading).to.be.false;
+        });
+
+        it('should perform client-side pagination', function() {
+            let list = new PageList({
+                    data: thingFactory(15),
+                    page_size: 5
+                });
+
+            expect(list.items).to.have.length(15);
+            expect(list.data).to.have.length(list.page_size);
+            expect(list.page).to.equal(1);
+            expect(list.pages).to.equal(3);
+            expect(list.data[0].id).to.equal(1);
+
+            list.nextPage();
+            expect(list.page).to.equal(2);
+            expect(list.pages).to.equal(3);
+            expect(list.data[0].id).to.equal(6);
+
+            list.nextPage();
+            expect(list.page).to.equal(3);
+            expect(list.pages).to.equal(3);
+            expect(list.data[0].id).to.equal(11);
+
+            list.nextPage();
+            expect(list.page).to.equal(3);
+            expect(list.pages).to.equal(3);
+            expect(list.data[0].id).to.equal(11);
+
+            list.previousPage();
+            expect(list.page).to.equal(2);
+            expect(list.pages).to.equal(3);
+            expect(list.data[0].id).to.equal(6);
+
+            list.previousPage();
+            expect(list.page).to.equal(1);
+            expect(list.pages).to.equal(3);
+            expect(list.data[0].id).to.equal(1);
+
+            list.previousPage();
+            expect(list.page).to.equal(1);
+            expect(list.pages).to.equal(3);
+            expect(list.data[0].id).to.equal(1);
+
+            expect(this.requests).to.have.length(0);
+        });
+
+        it('should perform client-side sorting', function() {
+            let pageSize = 3,
+                list = new PageList({
+                    data: thingFactory(2 * pageSize).concat(thingFactory(1, 'aaa'), thingFactory(1, 'zzz')),
+                    page_size: pageSize
+                }),
+                total = 2 * pageSize + 2;
+
+            expect(list.items).to.have.length(total);
+            expect(list.data).to.have.length(list.page_size);
+            expect(list.page).to.equal(1);
+            expect(list.pages).to.equal(3);
+            expect(list.data[0].id).to.equal(1);
+
+            // Sort ascending
+            list.sort('name', false);
+            expect(list.items).to.have.length(total);
+            expect(list.data).to.have.length(list.page_size);
+            expect(list.page).to.equal(1);
+            expect(list.pages).to.equal(3);
+            expect(list.data[0].name).to.equal('aaa');
+
+            list.nextPage();
+            list.nextPage();
+            expect(list.page).to.equal(3);
+            expect(list.data[list.data.length - 1].name).to.equal('zzz');
+
+            // Sort descending
+            list.sort('name', true);
+            expect(list.items).to.have.length(total);
+            expect(list.data).to.have.length(list.page_size);
+            expect(list.page).to.equal(1);
+            expect(list.pages).to.equal(3);
+            expect(list.data[0].name).to.equal('zzz');
+
+            // Sort toggle (reverse current sort)
+            list.sort('name');
+            expect(list.items).to.have.length(total);
+            expect(list.data).to.have.length(list.page_size);
+            expect(list.page).to.equal(1);
+            expect(list.pages).to.equal(3);
+            expect(list.data[0].name).to.equal('aaa');
+
+            expect(this.requests).to.have.length(0);
+        });
+
+        it('should perform client-side filtering with pagination', function() {
+            let pageSize = 2,
+                list = new PageList({
+                    data: thingFactory(pageSize).concat(
+                        thingFactory(2 * pageSize, 'xxx'),
+                        thingFactory(pageSize)
+                    ),
+                    search: 'name',
+                    page_size: pageSize
+                });
+
+            expect(list.has_search).to.be.true;
+            expect(list.data).to.have.length(pageSize);
+            expect(list.items).to.have.length(4 * pageSize);
+            expect(list.page).to.equal(1);
+            expect(list.pages).to.equal(4);
+            expect(list.data[0].id).to.equal(1);
+
+            list.search('xxx');
+
+            expect(list.page).to.equal(1);
+            expect(list.pages).to.equal(2);
+            expect(list.data).to.have.length(pageSize);
+            expect(list.data[0].id).to.equal(3);
+            expect(list.items).to.have.length(4 * pageSize);
+
+            list.nextPage();
+            expect(list.page).to.equal(2);
+            expect(list.pages).to.equal(2);
+            expect(list.data[0].id).to.equal(5);
+
+            list.nextPage();
+            expect(list.page).to.equal(2);
+            expect(list.pages).to.equal(2);
+            expect(list.data[0].id).to.equal(5);
+
+            list.previousPage();
+            expect(list.page).to.equal(1);
+            expect(list.pages).to.equal(2);
+            expect(list.data[0].id).to.equal(3);
+
+            list.previousPage();
+            expect(list.page).to.equal(1);
+            expect(list.pages).to.equal(2);
+            expect(list.data[0].id).to.equal(3);
+
+            expect(this.requests).to.have.length(0);
+        });
+
+        describe('Vue.js integration', function() {
+
+            afterEach(function() {
+                fixture.cleanup();
+            });
+
+            it('allows to watch changes', function() {
+                let vm = new Vue({
+                        el: fixture.set('<div/>')[0],
+                        template: `<ul v-el="list">
+                                        <li v-repeat=things.data>{{name}}</li>
+                                    </ul>`,
+                        data: {
+                            things: new List({
+                                ns: 'things',
+                                fetch: 'list_things'
+                            })
+                        }
+                    }),
+                    response = JSON.stringify(thingFactory(3));
+
+                expect(vm.$$.list.children).to.have.length(0);
+                vm.things.fetch({id: 'abc'});
+                this.requests[0].respond(200, {'Content-Type': 'application/json'}, response);
+
+                expect(vm.$$.list.children).to.have.length(3);
+            });
+
+        });
+
+    });
+});


### PR DESCRIPTION
This pull request make use of Sifter.js (already used by selectize.js)  for client-side lists search and sort.
In the same time, it start testing list and pagelist.

This pull-request depends on brianreavis/sifter.js#27 for nested fields support (sort on metrics).