### PR TITLE
Ability to edit posts as drafts, fix etalab/udata#131

### DIFF
--- a/js/components/post/form.vue
+++ b/js/components/post/form.vue
@@ -29,6 +29,9 @@ module.exports = {
                     id: 'tags',
                     label: this._('Tags'),
                     widget: 'tag-completer'
+                }, {
+                    id: 'private',
+                    label: this._('Draft')
                 }]
         };
     },

--- a/js/components/post/list.vue
+++ b/js/components/post/list.vue
@@ -45,6 +45,13 @@ module.exports = {
                 align: 'left',
                 type: 'timeago',
                 width: 120
+            }, {
+                label: this._('Access'),
+                key: 'private',
+                sort: 'private',
+                align: 'left',
+                type: 'visibility',
+                width: 120
             }]
         };
     },

--- a/js/models/post.js
+++ b/js/models/post.js
@@ -13,6 +13,13 @@ export default class Post extends Model {
         return this;
     }
 
+    update(data) {
+        this.$api('posts.update_post', {
+            post: this.id,
+            payload: data
+        }, this.on_fetched);
+    }
+
     save() {
         let data = {payload: this},
             endpoint = 'posts.create_post';

--- a/js/views/post-wizard.vue
+++ b/js/views/post-wizard.vue
@@ -24,8 +24,7 @@ module.exports = {
                 component: 'post-form',
                 next: function(component) {
                     if (component.$.form.validate()) {
-                        this.post.$data = component.$.form.serialize();
-                        this.post.save();
+                        Object.assign(this.post, component.$.form.serialize());
                         return true;
                     }
                 }.bind(this)

--- a/js/views/post.vue
+++ b/js/views/post.vue
@@ -22,6 +22,7 @@ module.exports = {
             post: new Post(),
             meta: {
                 title: null,
+                page: null,
                 subtitle: this._('Post')
             }
         };
@@ -46,6 +47,12 @@ module.exports = {
         post_id: function(id) {
             if (id) {
                 this.post.fetch(id);
+            }
+        },
+        'post.page': function(page) {
+            if (page) {
+                this.meta.page = page;
+                this.$dispatch('meta:updated', this.meta);
             }
         },
         'post.name': function(name) {


### PR DESCRIPTION
As a producer, I want to save posts as drafts in order to check the rendering and allow peer-review.

<img width="1020" alt="capture d ecran 2015-07-29 a 10 34 24" src="https://cloud.githubusercontent.com/assets/3556/8953270/7272f5e4-35dd-11e5-8ab0-0c8465c8a78e.png">
